### PR TITLE
add patches to compile jsk packages

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -1174,6 +1174,8 @@ def get_argument_parser():
         help="Prevents a pull request from being opened after release")
     add('--no-web', default=False, action='store_true',
         help="prevents a web browser from being opened at the end")
+    add('--skip-pip', default=False, action='store_true',
+        help="skip all pip rosdep keys")
     add('--pull-request-only', '-p', default=False, action='store_true',
         help="skips the release actions and only tries to open a pull request")
     add('--override-release-repository-url', default=None,
@@ -1204,6 +1206,9 @@ def main(sysargs=None):
 
     if args.no_web:
         os.environ['BLOOM_NO_WEBBROWSER'] = '1'
+
+    if args.skip_pip:
+        os.environ['BLOOM_SKIP_PIP'] = '1'
 
     try:
         os.environ['BLOOM_TRACK'] = args.track

--- a/bloom/generators/common.py
+++ b/bloom/generators/common.py
@@ -32,6 +32,7 @@
 
 from __future__ import print_function
 
+from os import environ
 import pkg_resources
 import sys
 import traceback
@@ -39,6 +40,7 @@ import traceback
 from bloom.logging import debug
 from bloom.logging import error
 from bloom.logging import info
+from bloom.logging import warning
 
 from bloom.rosdistro_api import get_distribution_type
 from bloom.rosdistro_api import get_index
@@ -118,6 +120,11 @@ def resolve_more_for_os(rosdep_key, view, installer, os_name, os_version):
                                              os_installers,
                                              default_os_installer)
     assert inst_key in os_installers
+    if 'BLOOM_SKIP_PIP' in environ and environ['BLOOM_SKIP_PIP'] == '1' and inst_key == 'pip':
+        warning("Key '{0}' resolved to '{1}' with installer '{2}' for os '{3}' '{4}', "
+                "but with the 'BLOOM_SKIP_PIP' environment variable set, this key is intentionally skipped."
+                .format(rosdep_key, installer.resolve(rule), inst_key, os_name, os_version))
+        return [], inst_key, default_os_installer
     return installer.resolve(rule), inst_key, default_os_installer
 
 

--- a/bloom/generators/debian/generate_cmd.py
+++ b/bloom/generators/debian/generate_cmd.py
@@ -67,6 +67,7 @@ def prepare_arguments(parser):
         help="path to or containing the package.xml of a package")
     action = parser.add_mutually_exclusive_group(required=False)
     add = action.add_argument
+    add('--skip-pip', default=False, action='store_true', help="skip all pip rosdep keys")
     add('--place-template-files', action='store_true',
         help="places debian/* template files only")
     add('--process-template-files', action='store_true',
@@ -114,6 +115,8 @@ def main(args=None, get_subs_fn=None):
     os_data = create_default_installer_context().get_os_name_and_version()
     os_name, os_version = os_data
     ros_distro = os.environ.get('ROS_DISTRO', 'indigo')
+    if args.skip_pip:
+        os.environ['BLOOM_SKIP_PIP'] = '1'
 
     # Allow args overrides
     os_name = args.os_name or os_name

--- a/bloom/generators/debian/generate_cmd.py
+++ b/bloom/generators/debian/generate_cmd.py
@@ -131,7 +131,8 @@ def main(args=None, get_subs_fn=None):
     for path, pkg in pkgs_dict.items():
         template_files = None
         try:
-            subs = get_subs_fn(pkg, os_name, os_version, ros_distro, args.debian_inc, args.native, args.skip_test_dependencies)
+            subs = get_subs_fn(pkg, os_name, os_version, ros_distro, args.debian_inc, args.native,
+                               args.skip_test_dependencies)
             if _place_template_files:
                 # Place template files
                 place_template_files(path, pkg.get_build_type())

--- a/bloom/generators/debian/generate_cmd.py
+++ b/bloom/generators/debian/generate_cmd.py
@@ -77,17 +77,20 @@ def prepare_arguments(parser):
     add('--ros-distro', help="ROS distro, e.g. %s (used for rosdep)" % get_non_eol_distros_prompt())
     add('-i', '--debian-inc', help="debian increment number", default='0')
     add('--native', action='store_true', help="generate native package")
+    add('--skip-test-dependencies', default=False, action='store_true',
+        help="skip to add test dependencies to package dependencies, i.e. Build-Depends")
     return parser
 
 
-def get_subs(pkg, os_name, os_version, ros_distro, deb_inc=0, native=False):
+def get_subs(pkg, os_name, os_version, ros_distro, deb_inc=0, native=False, skip_test_dependencies=False):
     return generate_substitutions_from_package(
         pkg,
         os_name,
         os_version,
         ros_distro,
         deb_inc=deb_inc,
-        native=native
+        native=native,
+        skip_test_dependencies=skip_test_dependencies
     )
 
 
@@ -125,7 +128,7 @@ def main(args=None, get_subs_fn=None):
     for path, pkg in pkgs_dict.items():
         template_files = None
         try:
-            subs = get_subs_fn(pkg, os_name, os_version, ros_distro, args.debian_inc, args.native)
+            subs = get_subs_fn(pkg, os_name, os_version, ros_distro, args.debian_inc, args.native, args.skip_test_dependencies)
             if _place_template_files:
                 # Place template files
                 place_template_files(path, pkg.get_build_type())

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -686,7 +686,6 @@ class DebianGenerator(BloomGenerator):
             # First branch is debian/[<rosdistro>/]<package>
             self.debian_branches.append(args[0][0])
             self.branch_args.extend(args)
-        self.skip_test_dependencies = args.skip_test_dependencies
 
     def summarize(self):
         info("Generating source debs for the packages: " + str(self.names))

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -686,7 +686,7 @@ class DebianGenerator(BloomGenerator):
             # First branch is debian/[<rosdistro>/]<package>
             self.debian_branches.append(args[0][0])
             self.branch_args.extend(args)
-        self.skip_test_dependencies=args.skip_test_dependencies
+        self.skip_test_dependencies = args.skip_test_dependencies
 
     def summarize(self):
         info("Generating source debs for the packages: " + str(self.names))

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -735,7 +735,6 @@ class DebianGenerator(BloomGenerator):
                                            retry=False)
                     if rule is None:
                         continue
-                    print([key, installer_key])
                     if installer_key != default_installer_key:
                         error("Key '{0}' resolved to '{1}' with installer '{2}', "
                               "which does not match the default installer '{3}'."

--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -152,7 +152,7 @@ def rosify_package_name(name, rosdistro):
     return 'ros-{0}-{1}'.format(rosdistro, name)
 
 
-def get_subs(pkg, os_name, os_version, ros_distro, deb_inc, native):
+def get_subs(pkg, os_name, os_version, ros_distro, deb_inc, native, skip_test_dependencies):
     # No fallback_resolver provided because peer packages not considered.
     subs = generate_substitutions_from_package(
         pkg,
@@ -161,7 +161,8 @@ def get_subs(pkg, os_name, os_version, ros_distro, deb_inc, native):
         ros_distro,
         RosDebianGenerator.default_install_prefix + ros_distro,
         deb_inc=deb_inc,
-        native=native
+        native=native,
+        skip_test_dependencies=skip_test_dependencies
     )
     subs['Package'] = rosify_package_name(subs['Package'], ros_distro)
     return subs

--- a/bloom/generators/rpm/generate_cmd.py
+++ b/bloom/generators/rpm/generate_cmd.py
@@ -67,6 +67,7 @@ def prepare_arguments(parser):
         help="path to or containing the package.xml of a package")
     action = parser.add_mutually_exclusive_group(required=False)
     add = action.add_argument
+    add('--skip-pip', default=False, action='store_true', help="skip all pip rosdep keys")
     add('--place-template-files', action='store_true',
         help="places rpm/* template file(s) only")
     add('--process-template-files', action='store_true',
@@ -107,6 +108,8 @@ def main(args=None, get_subs_fn=None):
     os_data = create_default_installer_context().get_os_name_and_version()
     os_name, os_version = os_data
     ros_distro = os.environ.get('ROS_DISTRO', 'indigo')
+    if args.skip_pip:
+        os.environ['BLOOM_SKIP_PIP'] = '1'
 
     # Allow args overrides
     os_name = args.os_name or os_name

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -577,7 +577,10 @@ class RpmGenerator(BloomGenerator):
                                            retry=False)
                     if rule is None:
                         continue
-                    if installer_key != default_installer_key:
+                    if 'BLOOM_SKIP_PIP' in os.environ and os.environ['BLOOM_SKIP_PIP'] == '1' and \
+                       installer_key == 'pip':
+                        pass
+                    elif installer_key != default_installer_key:
                         error("Key '{0}' resolved to '{1}' with installer '{2}', "
                               "which does not match the default installer '{3}'."
                               .format(key, rule, installer_key, default_installer_key))


### PR DESCRIPTION
update bloom to support `--skip-pip` and `--skip-test-dependencies `

- skip-pip  : skip using pip packages when create debs.  see https://github.com/ros-infrastructure/bloom/pull/412
- do not include test depends to Depends attributes of deb packages, the original bloom-release has this feaure, but it incldues est dependencies at some ponit .https://github.com/ros-infrastructure/bloom/pull/649/files#diff-7dc43dfeeccd0089cd7aa881452d316527c0a8f60d06956fce3fbf5d4bca5b7fL251-R254